### PR TITLE
radio: aidl: Fix initialization of variables

### DIFF
--- a/radio/aidl/compat/libradiocompat/data/structs.cpp
+++ b/radio/aidl/compat/libradiocompat/data/structs.cpp
@@ -30,9 +30,9 @@ V1_5::DataProfileInfo toHidl(const aidl::DataProfileInfo& info) {
     return {
             .profileId = V1_0::DataProfileId{info.profileId},
             .apn = info.apn,
-            .protocol = V1_4::PdpProtocolType{info.protocol},
-            .roamingProtocol = V1_4::PdpProtocolType{info.roamingProtocol},
-            .authType = V1_0::ApnAuthType{info.authType},
+            .protocol = static_cast<V1_4::PdpProtocolType>(info.protocol),
+            .roamingProtocol = static_cast<V1_4::PdpProtocolType>(info.roamingProtocol),
+            .authType = static_cast<V1_0::ApnAuthType>(info.authType),
             .user = info.user,
             .password = info.password,
             .type = V1_0::DataProfileInfoType{info.type},

--- a/radio/aidl/compat/libradiocompat/messaging/structs.cpp
+++ b/radio/aidl/compat/libradiocompat/messaging/structs.cpp
@@ -94,7 +94,7 @@ V1_0::CdmaSmsMessage toHidl(const aidl::CdmaSmsMessage& msg) {
 
 V1_0::ImsSmsMessage toHidl(const aidl::ImsSmsMessage& msg) {
     return {
-            .tech = V1_0::RadioTechnologyFamily{msg.tech},
+            .tech = static_cast<V1_0::RadioTechnologyFamily>(msg.tech),
             .retry = msg.retry,
             .messageRef = msg.messageRef,
             .cdmaMessage = toHidl(msg.cdmaMessage),

--- a/radio/aidl/compat/libradiocompat/modem/structs.cpp
+++ b/radio/aidl/compat/libradiocompat/modem/structs.cpp
@@ -30,7 +30,7 @@ namespace aidl = ::aidl::android::hardware::radio::modem;
 
 V1_0::NvWriteItem toHidl(const aidl::NvWriteItem& item) {
     return {
-            .itemId = V1_0::NvItem{item.itemId},
+            .itemId = static_cast<V1_0::NvItem>(item.itemId),
             .value = item.value,
     };
 }


### PR DESCRIPTION
Clang throws the following errors:

hardware/interfaces/radio/aidl/compat/libradiocompat/messaging/structs.cpp:97:49: error: cannot initialize a value of type 'V1_0::RadioTechnologyFamily' with an lvalue of type 'const ::aidl::android::hardware::radio::RadioTechnologyFamily'
            .tech = V1_0::RadioTechnologyFamily{msg.tech},
                                                ^~~~~~~~
1 error generated.

hardware/interfaces/radio/aidl/compat/libradiocompat/data/structs.cpp:33:47: error: cannot initialize a value of type 'V1_4::PdpProtocolType' with an lvalue of type 'const ::aidl::android::hardware::radio::data::PdpProtocolType'
            .protocol = V1_4::PdpProtocolType{info.protocol},
                                              ^~~~~~~~~~~~~
hardware/interfaces/radio/aidl/compat/libradiocompat/data/structs.cpp:34:54: error: cannot initialize a value of type 'V1_4::PdpProtocolType' with an lvalue of type 'const ::aidl::android::hardware::radio::data::PdpProtocolType'
            .roamingProtocol = V1_4::PdpProtocolType{info.roamingProtocol},
                                                     ^~~~~~~~~~~~~~~~~~~~
hardware/interfaces/radio/aidl/compat/libradiocompat/data/structs.cpp:35:43: error: cannot initialize a value of type 'V1_0::ApnAuthType' with an lvalue of type 'const ::aidl::android::hardware::radio::data::ApnAuthType'
            .authType = V1_0::ApnAuthType{info.authType},
                                          ^~~~~~~~~~~~~
3 errors generated.

...and many more so fix them.