### PR TITLE
libradiocompat: Deprecate getDeviceIdentity and use getImei instead

### DIFF
--- a/radio/aidl/compat/libradiocompat/modem/RadioModem.cpp
+++ b/radio/aidl/compat/libradiocompat/modem/RadioModem.cpp
@@ -45,14 +45,14 @@ ScopedAStatus RadioModem::getBasebandVersion(int32_t serial) {
 
 ScopedAStatus RadioModem::getDeviceIdentity(int32_t serial) {
     LOG_CALL << serial;
-    mHal1_5->getDeviceIdentity(serial);
+    LOG(ERROR) << " getDeviceIdentity is deprecated, use getImei instead";
+    respond()->getDeviceIdentityResponse(notSupported(serial), nullptr, nullptr, nullptr, nullptr);
     return ok();
 }
 
 ScopedAStatus RadioModem::getImei(int32_t serial) {
     LOG_CALL << serial;
-    LOG(ERROR) << " getImei is unsupported by HIDL HALs";
-    respond()->getImeiResponse(notSupported(serial), {});
+    mHal1_5->getDeviceIdentity(serial);
     return ok();
 }
 

--- a/radio/aidl/compat/libradiocompat/modem/RadioResponse-modem.cpp
+++ b/radio/aidl/compat/libradiocompat/modem/RadioResponse-modem.cpp
@@ -51,9 +51,10 @@ Return<void> RadioResponse::getBasebandVersionResponse(const V1_0::RadioResponse
 
 Return<void> RadioResponse::getDeviceIdentityResponse(  //
         const V1_0::RadioResponseInfo& info, const hidl_string& imei, const hidl_string& imeisv,
-        const hidl_string& esn, const hidl_string& meid) {
+        const hidl_string& /*esn*/, const hidl_string& /*meid*/) {
     LOG_CALL << info.serial;
-    modemCb()->getDeviceIdentityResponse(toAidl(info), imei, imeisv, esn, meid);
+    aidl::ImeiInfo imeiInfo(aidl::ImeiInfo::ImeiType::PRIMARY, imei, imeisv);
+    modemCb()->getImeiResponse(toAidl(info), imeiInfo);
     return {};
 }
 


### PR DESCRIPTION
Change-Id: If38b98ad480e4a0e80200276bf73d4a60abf3b26

Fixes unknown IMEI if using AOSP hidl => aidl radio wrapper